### PR TITLE
Use CSS.supports to more accurately detect support for scroll-snap-align

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -673,12 +673,7 @@ export default () => {
   /**
    * Feature detect scroll-snap-type, if it exists then do nothing (return)
    */
-  if ('scrollSnapAlign' in document.documentElement.style ||
-      'webkitScrollSnapAlign' in document.documentElement.style ||
-      'msScrollSnapAlign' in document.documentElement.style) {
-    // just return void to stop executing the polyfill.
-    return
-  }
+  if (typeof CSS != 'undefined' && CSS.supports('scroll-snap-align')) return;
 
   Polyfill({
     declarations: [


### PR DESCRIPTION
Because iOS 11 has the property in document.documentElement.style, but does not in fact support scroll snapping, we use CSS.supports() to detect the feature instead. Any browser that supports snapping will be new enough for modern feature detection too.